### PR TITLE
Update LoginServices for Shadowbringers

### DIFF
--- a/LaunchXIV/FFXIVLoginServices.swift
+++ b/LaunchXIV/FFXIVLoginServices.swift
@@ -16,6 +16,7 @@ public enum FFXIVExpansionLevel: UInt32 {
     case aRealmReborn = 0
     case heavensward = 1
     case stormblood = 2
+    case shadowbringers = 3
 }
 
 public enum FFXIVRegion: UInt32 {


### PR DESCRIPTION
My local copy of this app would launch my Shadowbringers-enabled account but only provisioned for ARR until I built my own local copy with this change.